### PR TITLE
Demote DynamicCities as a gameplay template in favor of MedievalCities so there is a culture definition present.

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -3,8 +3,9 @@
     "version" : "0.2.0-SNAPSHOT",
     "author" : "Cpt Crunchy",
     "displayName" : "Dynamic Cities",
-    "description" : "Simulates complex city development over progressing game time based on the worlds resources",
-    "dependencies" : [{
+    "description" : "Simulates complex city development over progressing game time based on the worlds resources. Needs a city culture to actually create cities.",
+    "dependencies" : [
+        {
             "id" : "Core",
             "minVersion" : "1.0.0"
         },
@@ -32,8 +33,8 @@
             "id" : "StructuralResources",
             "minVersion" : "0.2.1-SNAPSHOT"
         }
-     ],
-    "isGameplay" : "true",
+    ],
+    "isGameplay" : "false",
     "serverSideOnly" : false,
     "defaultWorldGenerator" : "DynamicCities:DynamicCitiesPerlin"
 }


### PR DESCRIPTION
May be temporary as MedievalCities could serve as more of an independent resource, with a third module set up as the actual gameplay controller eventually.

PR for documentation purposes as I'll insta-merge it to get a nice working Alpha 5 candidate built :-)

Fixes #23 or at least shifts things around to where it'll be harder to crash without a culture present (you'd have to pick DC solo - if it even crashes anymore, maybe just doesn't generate cities?)

Curious how we might eventually structure the base framework vs culture packs vs actual gameplay.
