### PR TITLE
Update settlements and regions to use sector-scope entities

### DIFF
--- a/src/main/java/org/terasology/dynamicCities/region/RegionEntityProvider.java
+++ b/src/main/java/org/terasology/dynamicCities/region/RegionEntityProvider.java
@@ -24,7 +24,8 @@ import org.terasology.dynamicCities.region.components.TreeFacetComponent;
 import org.terasology.dynamicCities.region.components.UnregisteredRegionComponent;
 import org.terasology.dynamicCities.sites.SiteFacet;
 import org.terasology.dynamicCities.world.trees.TreeFacet;
-import org.terasology.entitySystem.entity.EntityStore;
+import org.terasology.entitySystem.entity.EntityBuilder;
+import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.logic.location.LocationComponent;
 import org.terasology.math.Region3i;
 import org.terasology.math.geom.Vector2i;
@@ -36,6 +37,8 @@ import org.terasology.world.generation.Region;
 import org.terasology.world.generation.facets.SurfaceHeightFacet;
 import org.terasology.world.generation.facets.base.BaseFieldFacet2D;
 
+import static org.terasology.entitySystem.entity.internal.EntityScope.SECTOR;
+
 /**
  * Add an entity for each region to serve as storage for relevant data
  * At worldgen create for each region one
@@ -45,6 +48,11 @@ import org.terasology.world.generation.facets.base.BaseFieldFacet2D;
 
 public class RegionEntityProvider implements EntityProvider {
 
+    private EntityManager entityManager;
+
+    public RegionEntityProvider(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
 
     @Override
     public void process(Region region, EntityBuffer buffer) {
@@ -58,27 +66,28 @@ public class RegionEntityProvider implements EntityProvider {
             TreeFacet treeFacet = region.getFacet(TreeFacet.class);
             SiteFacet siteFacet = region.getFacet(SiteFacet.class);
 
-            EntityStore entityStore = new EntityStore();
+            EntityBuilder builder = entityManager.newBuilder();
+            builder.setScope(SECTOR);
 
             RoughnessFacetComponent roughnessFacetComponent = new RoughnessFacetComponent(roughnessFacet);
             ResourceFacetComponent resourceFacetComponent = new ResourceFacetComponent(resourceFacet);
             TreeFacetComponent treeFacetComponent = new TreeFacetComponent(treeFacet);
-            entityStore.addComponent(roughnessFacetComponent);
-            entityStore.addComponent(resourceFacetComponent);
-            entityStore.addComponent(treeFacetComponent);
+            builder.addComponent(roughnessFacetComponent);
+            builder.addComponent(resourceFacetComponent);
+            builder.addComponent(treeFacetComponent);
 
             LocationComponent locationComponent = new LocationComponent(worldRegion.center());
-            entityStore.addComponent(locationComponent);
+            builder.addComponent(locationComponent);
 
 
             if (siteFacet.getSiteComponent() != null) {
-                entityStore.addComponent(siteFacet.getSiteComponent());
+                builder.addComponent(siteFacet.getSiteComponent());
             }
 
             //Region component is used as identifier for a region entity
-            entityStore.addComponent(new UnregisteredRegionComponent());
-            entityStore.addComponent(new NetworkComponent());
-            buffer.enqueue(entityStore);
+            builder.addComponent(new UnregisteredRegionComponent());
+            builder.addComponent(new NetworkComponent());
+            buffer.enqueue(builder);
 
         }
    }

--- a/src/main/java/org/terasology/dynamicCities/world/PerlinFacetedWorldGenerator.java
+++ b/src/main/java/org/terasology/dynamicCities/world/PerlinFacetedWorldGenerator.java
@@ -32,6 +32,7 @@ import org.terasology.dynamicCities.region.RoughnessProvider;
 import org.terasology.dynamicCities.sites.SiteFacetProvider;
 import org.terasology.dynamicCities.world.trees.DefaultTreeProvider;
 import org.terasology.engine.SimpleUri;
+import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.logic.spawner.FixedSpawner;
 import org.terasology.math.geom.ImmutableVector2i;
@@ -51,6 +52,9 @@ public class PerlinFacetedWorldGenerator extends BaseFacetedWorldGenerator {
 
     @In
     private WorldGeneratorPluginLibrary worldGeneratorPluginLibrary;
+
+    @In
+    private EntityManager entityManager;
 
     public PerlinFacetedWorldGenerator(SimpleUri uri) {
         super(uri);
@@ -83,7 +87,7 @@ public class PerlinFacetedWorldGenerator extends BaseFacetedWorldGenerator {
                 .addProvider(new DefaultTreeProvider())
                 //.addProvider(new PlateauProvider(spawnPos, seaLevel + 4, 10, 30))
                 .addProvider(new ResourceProvider())
-                .addEntities(new RegionEntityProvider())
+                .addEntities(new RegionEntityProvider(entityManager))
                 .addRasterizer(new SolidRasterizer())
                 .addPlugins()
                 .addRasterizer(new FloraRasterizer())


### PR DESCRIPTION
This updates DynamicCities to use sector-scope entities, and use the sector-level simulation introduced in https://github.com/Vizaxo/Terasology/pull/5.