### PR TITLE
[v2.0.0] Update settlements to use sector-scope simulation

### DIFF
--- a/src/main/java/org/terasology/dynamicCities/settlements/SettlementCachingSystem.java
+++ b/src/main/java/org/terasology/dynamicCities/settlements/SettlementCachingSystem.java
@@ -68,6 +68,7 @@ public class SettlementCachingSystem extends BaseComponentSystem {
             settlementsCacheComponent.settlementEntities = new HashMap<>();
             settlementsCacheComponent.networkCache = new ArrayList<>();
             settlementEntities = entityManager.create(settlementsCacheComponent, networkComponent);
+            settlementEntities.setSectorScope(10);
             settlementEntities.setAlwaysRelevant(true);
         } else {
             SettlementsCacheComponent settlementsCacheComponent = settlementEntities.getComponent(SettlementsCacheComponent.class);

--- a/src/main/java/org/terasology/dynamicCities/settlements/SettlementConstants.java
+++ b/src/main/java/org/terasology/dynamicCities/settlements/SettlementConstants.java
@@ -21,7 +21,7 @@ public abstract class SettlementConstants {
     public static final int DISTRICT_GRIDSIZE = 8;
     public static final int MIN_POPULATIONSIZE = 200;
     public static final int MAX_POPULATIONSIZE = 900;
-    public static final int MAX_BUILDINGSPAWN = 2;
+    public static final float MAX_BUILDINGS_PER_SECOND = 0.5f;
     public static final int MAX_DISTRICTS = 300;
     public static final int BUILD_RADIUS_INTERVALL = 50;
     public static final int BLOCKS_SET_PER_TICK = 10_000;


### PR DESCRIPTION
Update the settlement entities to use sector-scope simulation and the SectorRegionComponent.

This PR leaves as much stuff alone as possible, only changing what's necessary for sector-scope. I've also been working on swapping out the region entity system in favour of directly accessing the facet data, but that's still tangled in with commits from this PR and needs to be rebased before pushing.

Depends on https://github.com/MovingBlocks/Terasology/pull/3022 (so should be merged into a v2.0.0 branch, because it will break if used with the current develop TS branch)