### PR TITLE
Update ParcelList and RegionEntities Tests

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -11,7 +11,8 @@
         {"id" : "Minimap", "minVersion" : "1.0.0"},
         {"id" : "Economy", "minVersion" : "0.1.0"},
         {"id" : "StructureTemplates", "minVersion" : "0.3.0"},
-        {"id" : "StructuralResources", "minVersion" : "1.0.0"}
+        {"id" : "StructuralResources", "minVersion" : "1.0.0"},
+        {"id" : "ModuleTestingEnvironment", "minVersion" : "0.1.0"}
     ],
     "isGameplay" : "false",
     "serverSideOnly" : false,

--- a/src/test/java/org/terasology/facets/Grid2DFloatFacetTest.java
+++ b/src/test/java/org/terasology/facets/Grid2DFloatFacetTest.java
@@ -28,9 +28,8 @@ import org.terasology.world.generation.facets.base.FieldFacet3D;
 
 /**
  * Tests different implementations of {@link FieldFacet3D}.
- *
  */
-public class Grid2DFloatFacetTest{
+public class Grid2DFloatFacetTest {
 
     private Grid2DFloatFacet facet;
 
@@ -53,6 +52,7 @@ public class Grid2DFloatFacetTest{
             super(targetRegion, border, gridSize);
         }
     }
+
     /**
      * Check unset values
      */

--- a/src/test/java/org/terasology/facets/Grid2DObjectFacetTest.java
+++ b/src/test/java/org/terasology/facets/Grid2DObjectFacetTest.java
@@ -28,7 +28,6 @@ import org.terasology.world.generation.facets.base.ObjectFacet3D;
 
 /**
  * Tests different implementations of {@link ObjectFacet3D}.
- *
  */
 public class Grid2DObjectFacetTest {
 
@@ -80,6 +79,7 @@ public class Grid2DObjectFacetTest {
         Assert.assertEquals(new Vector2i(42, 62), facet.getWorldPoint(30, 50));
         Assert.assertEquals(new Vector2i(26, 46), facet.getWorldPoint(26, 46));
     }
+
     /**
      * Check unset values
      */
@@ -130,7 +130,6 @@ public class Grid2DObjectFacetTest {
         facet.setWorld(24, 46, 32);
         Assert.assertEquals(Integer.valueOf(32), facet.get(14, 16), 0.0);
     }
-
 
 
 }

--- a/src/test/java/parcels/ParcelListTest.java
+++ b/src/test/java/parcels/ParcelListTest.java
@@ -15,11 +15,27 @@
  */
 package parcels;
 
+import org.junit.Before;
+import org.junit.Test;
+import org.terasology.commonworld.Orientation;
+import org.terasology.dynamicCities.parcels.DynParcel;
+import org.terasology.dynamicCities.parcels.ParcelList;
+import org.terasology.math.geom.Rect2i;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ParcelListTest {
-/*
     public ParcelList parcels;
     public Rect2i[] shapes;
+
+    final String CLERICAL = "CLERICAL";
+    final String RESIDENTIAL = "RESIDENTIAL";
+    final String GOVERNMENTAL = "GOVERNMENTAL";
+
     @Before
     public void setup() {
         parcels = new ParcelList(1);
@@ -29,22 +45,22 @@ public class ParcelListTest {
         shapes[2] = Rect2i.createFromMinAndSize(-13, -13, 10, 10);
         shapes[3] = Rect2i.createFromMinAndSize(-5, -5, 100, 100);
         shapes[4] = Rect2i.createFromMinAndSize(-100, -100, 10, 10);
-        parcels.addParcel(new DynParcel(shapes[0], Orientation.EAST, Zone.CLERICAL, 0));
-        parcels.addParcel(new DynParcel(shapes[1], Orientation.EAST, Zone.RESIDENTIAL, 0));
-        parcels.addParcel(new DynParcel(shapes[2], Orientation.EAST, Zone.GOVERNMENTAL, 0));
+        parcels.addParcel(new DynParcel(shapes[0], Orientation.EAST, CLERICAL, 0));
+        parcels.addParcel(new DynParcel(shapes[1], Orientation.EAST, RESIDENTIAL, 0));
+        parcels.addParcel(new DynParcel(shapes[2], Orientation.EAST, GOVERNMENTAL, 0));
     }
 
     @Test
     public void testIntersection() {
-        assertEquals(true, parcels.isNotIntersecting(shapes[4]));
-        assertEquals(false, parcels.isNotIntersecting(shapes[3]));
+        assertTrue(parcels.isNotIntersecting(shapes[4]));
+        assertFalse(parcels.isNotIntersecting(shapes[3]));
     }
 
     @Test
     public void testZoneArea() {
-        assertEquals(100, parcels.clericalArea);
-        assertEquals(100, parcels.residentialArea);
-        assertEquals(100, parcels.governmentalArea);
+        Map<String, Integer> areas = parcels.areaPerZone;
+        assertEquals(100, (long) areas.get(CLERICAL));
+        assertEquals(100, (long) areas.get(RESIDENTIAL));
+        assertEquals(100, (long) areas.get(GOVERNMENTAL));
     }
-    */
 }

--- a/src/test/java/regions/RegionEntitiesTest.java
+++ b/src/test/java/regions/RegionEntitiesTest.java
@@ -74,7 +74,6 @@ public class RegionEntitiesTest extends ModuleTestingEnvironment {
 
     @Test
     public void testSimpleGet() {
-        assertEquals(200, 200);
         for (int i = 0; i < test.length; i++) {
             assertEquals(test[i], regionEntityManager.get(new Vector2i(pos[i].x(), pos[i].z())));
         }

--- a/src/test/java/regions/RegionEntitiesTest.java
+++ b/src/test/java/regions/RegionEntitiesTest.java
@@ -16,18 +16,42 @@
 
 package regions;
 
-public class RegionEntitiesTest {
-/*
-    private RegionEntitiesComponent regionEntitiesComponent;
-    private EntityRef[] test;
+import com.google.common.collect.Sets;
+import org.junit.Test;
+import org.terasology.dynamicCities.region.RegionEntityManager;
+import org.terasology.dynamicCities.region.components.RegionEntitiesComponent;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.moduletestingenvironment.ModuleTestingEnvironment;
 
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class RegionEntitiesTest extends ModuleTestingEnvironment {
+
+    private RegionEntitiesComponent regionEntitiesComponent;
+    private RegionEntityManager regionEntityManager;
+
+    private EntityRef[] test;
     private Vector3f[] pos = new Vector3f[4];
+
+    @Override
+    public Set<String> getDependencies() {
+        return Sets.newHashSet("engine", "DynamicCities", "ModuleTestingEnvironment");
+    }
+
+    /*
     @Before
     public void setup() {
         pos[0] = new Vector3f(16, 0, 16);
         pos[1] = new Vector3f(16, 0, -16);
         pos[2] = new Vector3f(-16, 0, 16);
         pos[3] = new Vector3f(-16, 0, -16);
+
+//        regionEntityManager = getHostContext().get(RegionEntityManager.class);
+
+//        regionEntityManager = Mockito.mock(RegionEntityManager.class);
 
         regionEntitiesComponent = new RegionEntitiesComponent(64);
         test = new EntityRef[4];
@@ -36,26 +60,36 @@ public class RegionEntitiesTest {
             test[i] = Mockito.mock(EntityRef.class);
             loc[i] = new LocationComponent(pos[i]);
             Mockito.when(test[i].getComponent(LocationComponent.class)).thenReturn(loc[i]);
-            regionEntitiesComponent.add(test[i]);
+//            regionEntitiesComponent.add(test[i]);
+//            regionEntityManager.add(test[i]);
         }
-
-
     }
+    */
 
     @Test
     public void testSimpleGet() {
-        for (int i = 0; i < test.length; i++) {
-            assertEquals(test[i], regionEntitiesComponent.get(new Vector2i(pos[i].x(), pos[i].z())));
-        }
+        assertEquals(200, 200);
+
+//        regionEntityManager = getHostContext().get(RegionEntityManager.class);
+//
+//        for (EntityRef entityRef : test) {
+//            regionEntityManager.add(entityRef);
+//        }
+//
+//        for (int i = 0; i < test.length; i++) {
+//            assertEquals(test[i], regionEntityManager.get(new Vector2i(pos[i].x(), pos[i].z())));
+//        }
     }
 
+    /*
     @Test
     public void testNearestGet() {
-        assertEquals(test[0], regionEntitiesComponent.getNearest(new Vector2i(21, 13)));
-        assertEquals(test[1], regionEntitiesComponent.getNearest(new Vector2i(14, -13)));
-        assertEquals(test[2], regionEntitiesComponent.getNearest(new Vector2i(-22, 19)));
-        assertEquals(test[3], regionEntitiesComponent.getNearest(new Vector2i(-13, -19)));
+        assertEquals(test[0], regionEntityManager.getNearest(new Vector2i(21, 13)));
+        assertEquals(test[1], regionEntityManager.getNearest(new Vector2i(14, -13)));
+        assertEquals(test[2], regionEntityManager.getNearest(new Vector2i(-22, 19)));
+        assertEquals(test[3], regionEntityManager.getNearest(new Vector2i(-13, -19)));
     }
+
     @Test
     public void testIsLoaded() {
         assertEquals(true, regionEntitiesComponent.cellIsLoaded(new Vector2i(0, 0)));
@@ -70,10 +104,8 @@ public class RegionEntitiesTest {
     @Test
     public void testGetRegionssInCell() {
         List<EntityRef> testList = new ArrayList<>();
-        for (EntityRef region : test) {
-            testList.add(region);
-        }
+        Collections.addAll(testList, test);
         assertEquals(testList, regionEntitiesComponent.getRegionsInCell(new Vector2i(0, 0)));
     }
-*/
+    */
 }

--- a/src/test/java/regions/RegionEntitiesTest.java
+++ b/src/test/java/regions/RegionEntitiesTest.java
@@ -17,71 +17,69 @@
 package regions;
 
 import com.google.common.collect.Sets;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.terasology.dynamicCities.region.RegionEntityManager;
-import org.terasology.dynamicCities.region.components.RegionEntitiesComponent;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.logic.location.LocationComponent;
+import org.terasology.math.geom.Vector2i;
 import org.terasology.math.geom.Vector3f;
 import org.terasology.moduletestingenvironment.ModuleTestingEnvironment;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class RegionEntitiesTest extends ModuleTestingEnvironment {
-
-    private RegionEntitiesComponent regionEntitiesComponent;
     private RegionEntityManager regionEntityManager;
 
     private EntityRef[] test;
-    private Vector3f[] pos = new Vector3f[4];
+    private Vector3f[] pos = new Vector3f[10];
 
     @Override
     public Set<String> getDependencies() {
         return Sets.newHashSet("engine", "DynamicCities", "ModuleTestingEnvironment");
     }
 
-    /*
     @Before
-    public void setup() {
+    public void setupEntityRefs() {
         pos[0] = new Vector3f(16, 0, 16);
         pos[1] = new Vector3f(16, 0, -16);
         pos[2] = new Vector3f(-16, 0, 16);
         pos[3] = new Vector3f(-16, 0, -16);
+        pos[4] = new Vector3f(0, 0, 0);
+        pos[5] = new Vector3f(32, 0, 32);
+        pos[6] = new Vector3f(32, 0, -32);
+        pos[7] = new Vector3f(-32, 0, 32);
+        pos[8] = new Vector3f(-32, 0, -32);
+        pos[9] = new Vector3f(97, 0, -97);
 
-//        regionEntityManager = getHostContext().get(RegionEntityManager.class);
+        regionEntityManager = getHostContext().get(RegionEntityManager.class);
 
-//        regionEntityManager = Mockito.mock(RegionEntityManager.class);
-
-        regionEntitiesComponent = new RegionEntitiesComponent(64);
-        test = new EntityRef[4];
+        test = new EntityRef[10];
         LocationComponent[] loc = new LocationComponent[test.length];
         for (int i = 0; i < test.length; i++) {
             test[i] = Mockito.mock(EntityRef.class);
             loc[i] = new LocationComponent(pos[i]);
             Mockito.when(test[i].getComponent(LocationComponent.class)).thenReturn(loc[i]);
-//            regionEntitiesComponent.add(test[i]);
-//            regionEntityManager.add(test[i]);
+            regionEntityManager.add(test[i]);
         }
     }
-    */
 
     @Test
     public void testSimpleGet() {
         assertEquals(200, 200);
-
-//        regionEntityManager = getHostContext().get(RegionEntityManager.class);
-//
-//        for (EntityRef entityRef : test) {
-//            regionEntityManager.add(entityRef);
-//        }
-//
-//        for (int i = 0; i < test.length; i++) {
-//            assertEquals(test[i], regionEntityManager.get(new Vector2i(pos[i].x(), pos[i].z())));
-//        }
+        for (int i = 0; i < test.length; i++) {
+            assertEquals(test[i], regionEntityManager.get(new Vector2i(pos[i].x(), pos[i].z())));
+        }
     }
 
-    /*
     @Test
     public void testNearestGet() {
         assertEquals(test[0], regionEntityManager.getNearest(new Vector2i(21, 13)));
@@ -92,20 +90,18 @@ public class RegionEntitiesTest extends ModuleTestingEnvironment {
 
     @Test
     public void testIsLoaded() {
-        assertEquals(true, regionEntitiesComponent.cellIsLoaded(new Vector2i(0, 0)));
-        assertEquals(true, regionEntitiesComponent.cellIsLoaded(new Vector2i(16, 0)));
-        assertEquals(true, regionEntitiesComponent.cellIsLoaded(new Vector2i(0, -16)));
-        assertEquals(true, regionEntitiesComponent.cellIsLoaded(new Vector2i(24, -25)));
-        assertEquals(false, regionEntitiesComponent.cellIsLoaded(new Vector2i(64, -64)));
-        assertEquals(false, regionEntitiesComponent.cellIsLoaded(new Vector2i(48, -35)));
-        assertEquals(false, regionEntitiesComponent.cellIsLoaded(new Vector2i(10, -36)));
+        assertTrue(regionEntityManager.cellIsLoaded(new Vector2i(0, 0)));
+        assertTrue(regionEntityManager.cellIsLoaded(new Vector2i(16, 0)));
+        assertTrue(regionEntityManager.cellIsLoaded(new Vector2i(0, -25)));
+        assertFalse(regionEntityManager.cellIsLoaded(new Vector2i(98, -124)));
+        assertFalse(regionEntityManager.cellIsLoaded(new Vector2i(351, 234)));
+        assertFalse(regionEntityManager.cellIsLoaded(new Vector2i(153, -134)));
     }
 
     @Test
-    public void testGetRegionssInCell() {
+    public void testGetRegionsInCell() {
         List<EntityRef> testList = new ArrayList<>();
-        Collections.addAll(testList, test);
-        assertEquals(testList, regionEntitiesComponent.getRegionsInCell(new Vector2i(0, 0)));
+        testList.addAll(Arrays.asList(test).subList(0, 5));
+        assertEquals(testList, regionEntityManager.getRegionsInCell(new Vector2i(0, 0)));
     }
-    */
 }


### PR DESCRIPTION
- Fixed formatting on Grid2DFloatFacetTest and Grid2DObjectFacetTest
- Adapt ParcelListTest to the current Zone system
- Update RegionEntitiesTest to now use the ModuleTestingEnvironment and the RegionEntityManager in accordance with ECS

**To test:**
Run the test suite. All tests should pass.