### PR TITLE
Remove sufficient grass condition

### DIFF
--- a/src/main/java/org/terasology/dynamicCities/sites/SiteFacetProvider.java
+++ b/src/main/java/org/terasology/dynamicCities/sites/SiteFacetProvider.java
@@ -68,8 +68,7 @@ public class SiteFacetProvider implements ConfigurableFacetProvider {
         Region3i coreReg = region.getRegion();
         SiteFacet siteFacet = new SiteFacet(coreReg, border);
 
-        if (roughnessFacet.getMeanDeviation() < 0.3f && roughnessFacet.getMeanDeviation() > 0
-                && resourceFacet.getResourceSum(ResourceType.GRASS.toString()) > 750) {
+        if (roughnessFacet.getMeanDeviation() < 0.3f && roughnessFacet.getMeanDeviation() > 0) {
             BaseVector2i minPos = new Vector2i();
             float minDev = 10;
             for (BaseVector2i pos : roughnessFacet.getGridWorldRegion().contents()) {


### PR DESCRIPTION
The SiteFacetProvider no longer looks for sufficient grass when deciding if
a site is suitable for building a city.