### PR TITLE
fix: `ModuleTestingEnvironment` dependency

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -14,7 +14,7 @@
         { "id": "Economy", "minVersion": "1.0.0" },
         { "id": "Inventory", "minVersion": "1.1.0" },
         { "id": "Minimap", "minVersion": "1.0.0" },
-        { "id": "ModuleTestingEnvironment", "minVersion": "0.1.0" },
+        { "id": "ModuleTestingEnvironment", "minVersion": "0.2.0" },
         { "id": "NameGenerator", "minVersion": "1.0.0" },
         { "id": "StructureTemplates", "minVersion": "1.0.0" },
         { "id": "StructuralResources", "minVersion": "2.1.0" }

--- a/module.txt
+++ b/module.txt
@@ -14,7 +14,7 @@
         { "id": "Economy", "minVersion": "1.0.0" },
         { "id": "Inventory", "minVersion": "1.1.0" },
         { "id": "Minimap", "minVersion": "1.0.0" },
-        { "id": "ModuleTestingEnvironment", "minVersion": "0.2.0" },
+        { "id": "ModuleTestingEnvironment", "minVersion": "0.2.0", "optional": true },
         { "id": "NameGenerator", "minVersion": "1.0.0" },
         { "id": "StructureTemplates", "minVersion": "1.0.0" },
         { "id": "StructuralResources", "minVersion": "2.1.0" }


### PR DESCRIPTION
- pre-release minor versions seem to be treated like real-release major versions wrt inclusion/exclusion