### PR TITLE
feat: Allow decimals in a culture's building need values

### DIFF
--- a/src/main/java/org/terasology/dynamicCities/population/CultureComponent.java
+++ b/src/main/java/org/terasology/dynamicCities/population/CultureComponent.java
@@ -26,7 +26,7 @@ import java.util.Map;
 
 public class CultureComponent implements Component {
 
-    public Map<String, Integer> buildingNeedPerZone;
+    public Map<String, Float> buildingNeedPerZone;
     public String name;
     public List<String> availableBuildings;
     public List<String> residentialZones;
@@ -34,7 +34,7 @@ public class CultureComponent implements Component {
     public String theme = null;
 
 
-    public int getBuildingNeedsForZone(String zone) {
+    public float getBuildingNeedsForZone(String zone) {
         if (buildingNeedPerZone.containsKey(zone)) {
             return buildingNeedPerZone.get(zone);
         } else {
@@ -44,7 +44,7 @@ public class CultureComponent implements Component {
 
     public float getProcentualOfZone(String zone) {
         float total = 0;
-        for (Integer need : buildingNeedPerZone.values()) {
+        for (Float need : buildingNeedPerZone.values()) {
             total += need;
         }
         if (total == 0) {

--- a/src/main/java/org/terasology/dynamicCities/utilities/Toolbox.java
+++ b/src/main/java/org/terasology/dynamicCities/utilities/Toolbox.java
@@ -104,9 +104,9 @@ public class Toolbox {
             iterator.set(iterator.next().toLowerCase());
         }
     }
-    public static Map<String, Integer> stringsToLowerCase(Map<String, Integer> map) {
+    public static Map<String, Float> stringsToLowerCase(Map<String, Float> map) {
         Set<String> keySet = Collections.unmodifiableSet(map.keySet());
-        Map<String, Integer> newMap = new HashMap<>();
+        Map<String, Float> newMap = new HashMap<>();
         for (String key : keySet) {
             newMap.put(key.toLowerCase(), map.get(key));
         }


### PR DESCRIPTION
Allows the usage of decimal building needs values inside of a culture component. This change allows for the ratios of buildings within a city to be tweaked with much greater accuracy.

Required for [Terasology/MetalRenegades#67](https://github.com/Terasology/MetalRenegades/pull/67) to work.