### PR TITLE
fix: adapt to changes to BlockRegionIterable

### DIFF
--- a/src/main/java/org/terasology/dynamicCities/construction/Construction.java
+++ b/src/main/java/org/terasology/dynamicCities/construction/Construction.java
@@ -108,6 +108,7 @@ import org.terasology.world.block.Block;
 import org.terasology.world.block.BlockManager;
 import org.terasology.world.block.BlockRegion;
 import org.terasology.world.block.BlockRegionIterable;
+import org.terasology.world.block.BlockRegions;
 import org.terasology.world.block.entity.placement.PlaceBlocks;
 import org.terasology.world.generation.Border3D;
 import org.terasology.world.generation.facets.ElevationFacet;
@@ -667,11 +668,11 @@ public class Construction extends BaseComponentSystem {
             region = transformation.transformRegion(region);
             block = transformation.transformBlock(block);
             if (block.getBlockFamily() == blockManager.getBlockFamily("CoreAdvancedAssets:chest")) {
-                for (Vector3ic pos : BlockRegionIterable.region(region).build()) {
+                for (Vector3ic pos : BlockRegions.iterableInPlace(region)) {
                     entity.send(new SetBlockEvent(JomlUtil.from(pos), block));
                 }
             } else {
-                for (Vector3ic pos : BlockRegionIterable.region(region).build()) {
+                for (Vector3ic pos : BlockRegions.iterableInPlace(region)) {
                     entity.send(new BufferBlockEvent(JomlUtil.from(pos), block));
                 }
             }


### PR DESCRIPTION
Adapt to changes in https://github.com/MovingBlocks/Terasology/pull/4272

Required by https://github.com/Terasology/StructureTemplates/pull/47