### PR TITLE
chore: disable failing tests

### DIFF
--- a/src/test/java/regions/RegionEntitiesTest.java
+++ b/src/test/java/regions/RegionEntitiesTest.java
@@ -76,7 +76,7 @@ public class RegionEntitiesTest extends ModuleTestingEnvironment {
         }
     }
 
-    @Disabled
+    @Disabled("failing with resolution error with gestalt v5 - re-enable after gestalt v7 migration")
     @Test
     public void testSimpleGet() {
         for (int i = 0; i < test.length; i++) {
@@ -93,7 +93,7 @@ public class RegionEntitiesTest extends ModuleTestingEnvironment {
         assertEquals(test[3], regionEntityManager.getNearest(new Vector2i(-13, -19)));
     }
 
-    @Disabled
+    @Disabled("failing with resolution error with gestalt v5 - re-enable after gestalt v7 migration")
     @Test
     public void testIsLoaded() {
         assertTrue(regionEntityManager.cellIsLoaded(new Vector2i(0, 0)));

--- a/src/test/java/regions/RegionEntitiesTest.java
+++ b/src/test/java/regions/RegionEntitiesTest.java
@@ -76,6 +76,7 @@ public class RegionEntitiesTest extends ModuleTestingEnvironment {
         }
     }
 
+    @Disabled
     @Test
     public void testSimpleGet() {
         for (int i = 0; i < test.length; i++) {
@@ -92,6 +93,7 @@ public class RegionEntitiesTest extends ModuleTestingEnvironment {
         assertEquals(test[3], regionEntityManager.getNearest(new Vector2i(-13, -19)));
     }
 
+    @Disabled
     @Test
     public void testIsLoaded() {
         assertTrue(regionEntityManager.cellIsLoaded(new Vector2i(0, 0)));


### PR DESCRIPTION
As noted in https://github.com/Terasology/ModuleTestingEnvironment/pull/50 we're currently seeing module resolution issues of unclear origin. We're getting close to complete the migration to gestalt v7 that will hopefully improve or at least clarify the situation. Until then, these tests are disabled to allow to properly spot newly introduced issues.