### PR TITLE
chore: update SolidRasterizer to use new Biome API to query block types

### DIFF
--- a/src/main/java/org/terasology/dynamicCities/world/SolidRasterizer.java
+++ b/src/main/java/org/terasology/dynamicCities/world/SolidRasterizer.java
@@ -54,68 +54,14 @@ public class SolidRasterizer extends CompatibleRasterizer {
             float density = solidityFacet.get(pos);
 
             if (surfaceFacet.get(pos)) {
-                setBlock(chunk, getSurfaceBlock(biome, posY - seaLevel), pos, resourceFacet);
+                setBlock(chunk, biome.getSurfaceBlock(pos, seaLevel), pos, resourceFacet);
             } else if (density > 0) {
-                setBlock(chunk, getBelowSurfaceBlock(density, biome), pos, resourceFacet);
+                setBlock(chunk, biome.getBelowSurfaceBlock(pos, density), pos, resourceFacet);
             } else if (posY == seaLevel && CoreBiome.SNOW == biome) {
                 setBlock(chunk, ice, pos, resourceFacet);
             } else if (posY <= seaLevel) {         // either OCEAN or SNOW
                 setBlock(chunk, water, pos, resourceFacet);
             }
-        }
-    }
-
-    private Block getSurfaceBlock(Biome type, int heightAboveSea) {
-        if (type instanceof CoreBiome) {
-            switch ((CoreBiome) type) {
-                case FOREST:
-                case PLAINS:
-                case MOUNTAINS:
-                    if (heightAboveSea > 96) {
-                        return snow;
-                    } else if (heightAboveSea > 0) {
-                        return grass;
-                    } else {
-                        return dirt;
-                    }
-                case SNOW:
-                    if (heightAboveSea > 0) {
-                        return snow;
-                    } else {
-                        return dirt;
-                    }
-                case DESERT:
-                case OCEAN:
-                case BEACH:
-                    return sand;
-            }
-        }
-        return dirt;
-    }
-
-    private Block getBelowSurfaceBlock(float density, Biome type) {
-        if (type instanceof CoreBiome) {
-            switch ((CoreBiome) type) {
-                case DESERT:
-                    if (density > 8) {
-                        return stone;
-                    } else {
-                        return sand;
-                    }
-                case BEACH:
-                    if (density > 2) {
-                        return stone;
-                    } else {
-                        return sand;
-                    }
-                case OCEAN:
-                    return stone;
-            }
-        }
-        if (density > 32) {
-            return stone;
-        } else {
-            return dirt;
         }
     }
 }


### PR DESCRIPTION
Now that CoreWorlds uses the new API (https://github.com/Terasology/CoreWorlds/pull/35), DynamicCities can use it as well. It makes the rasterizer much simpler, and allows Metal Renegades (which uses DynamicCities' SolidRasterizer) to add new biomes without changing the rasterizer. This change shouldn't change the behavior of anything, if it does something else probably needs to be updated.