### PR TITLE
chore(BlockBufferSystem): reduce log spam

### DIFF
--- a/src/main/java/org/terasology/dynamicCities/construction/BlockBufferSystem.java
+++ b/src/main/java/org/terasology/dynamicCities/construction/BlockBufferSystem.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2016 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.dynamicCities.construction;
 
 import org.joml.Vector3i;
@@ -100,7 +87,6 @@ public class BlockBufferSystem extends BaseComponentSystem {
 
     public void setBlocks(int maxBlocksToSet) {
         Map<Vector3i, Block> blocksToPlace = new HashMap<>();
-        int removed = 0;
         int oldBufferSize = getBlockBufferSize();
 
         Iterator<Map.Entry<Vector3i, Block>> iter = buffer.entrySet().iterator();
@@ -109,14 +95,12 @@ public class BlockBufferSystem extends BaseComponentSystem {
             if (worldProvider.isBlockRelevant(block.getKey())) {
                 blocksToPlace.put(block.getKey(), block.getValue());
                 iter.remove();
-                removed++;
             }
         }
 
-        if (!blocksToPlace.isEmpty()) {
-            logger.info("Buffer before: {}, Placed: {}, Removed: {}, Buffer after: {}", oldBufferSize, blocksToPlace.size(), removed, getBlockBufferSize());
-            //worldProvider.setBlocks(blocksToPlace);
-            blocksToPlace.forEach((pos, block) -> worldProvider.setBlock(pos, block));
+        blocksToPlace.forEach((pos, block) -> worldProvider.setBlock(pos, block));
+        if (logger.isDebugEnabled() && !blocksToPlace.isEmpty()) {
+            logger.debug("Buffer before: {}, Placed: {}, Buffer after: {}", oldBufferSize, blocksToPlace.size(), getBlockBufferSize());
         }
     }
 


### PR DESCRIPTION
**Problem:** The state of the block buffer was logged at INFO level with each iteration.
    
**Solution:** Reduce the log level to DEBUG and only log if the level is enabled. As `removed` and the size of `blocksToPlace` were always the same additional field `removed` is removed.

While at it, I tried to improve the readability of `BlockBufferSystem#setBlocks` by making use of Java 8 Stream API.
Additionally, add a couple of docstrings, TODOs or FIXMEs here and there to prepare for a future module overhaul.

