### PR TITLE
feat: make SolidRasterizer and ResourceProvider scalable to enable LOD chunks

### DIFF
--- a/src/main/java/org/terasology/dynamicCities/region/ResourceProvider.java
+++ b/src/main/java/org/terasology/dynamicCities/region/ResourceProvider.java
@@ -1,51 +1,36 @@
-/*
- * Copyright 2016 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.dynamicCities.region;
 
 import org.terasology.dynamicCities.facets.ResourceFacet;
 import org.terasology.dynamicCities.facets.RoughnessFacet;
 import org.terasology.engine.world.generation.Border3D;
-import org.terasology.engine.world.generation.FacetProvider;
 import org.terasology.engine.world.generation.GeneratingRegion;
 import org.terasology.engine.world.generation.Produces;
+import org.terasology.engine.world.generation.ScalableFacetProvider;
 import org.terasology.engine.world.generator.plugin.RegisterPlugin;
+import org.terasology.math.TeraMath;
 
+/**
+ * This facet will be used to store information about the resources in its region.
+ *
+ * The actual data will be set through CompatibleRasterizer. It will be saved as a Component in the RegionEntity.
+ */
 @RegisterPlugin
 @Produces(ResourceFacet.class)
-/**
- * This facet will be used to store information about the resources in its region
- * The actual data will be set through CompatibleRasterizer
- * It will be saved as a Component in the RegionEntity
- */
-public class ResourceProvider implements FacetProvider {
+public class ResourceProvider implements ScalableFacetProvider {
 
     private final int gridSize = 32;
 
+    @Override
+    public void setSeed(long seed) {
+    }
 
     @Override
-    public void setSeed(long seed) { }
-
-    @Override
-    public void process(GeneratingRegion region) {
-
+    public void process(GeneratingRegion region, float scale) {
         Border3D border = region.getBorderForFacet(RoughnessFacet.class);
-        ResourceFacet facet = new ResourceFacet(region.getRegion(), border, gridSize);
+        ResourceFacet facet = new ResourceFacet(region.getRegion(), border, TeraMath.ceilToInt(gridSize / scale));
 
         region.setRegionFacet(ResourceFacet.class, facet);
     }
-
-
 }

--- a/src/main/java/org/terasology/dynamicCities/region/ResourceProvider.java
+++ b/src/main/java/org/terasology/dynamicCities/region/ResourceProvider.java
@@ -29,7 +29,7 @@ public class ResourceProvider implements ScalableFacetProvider {
     @Override
     public void process(GeneratingRegion region, float scale) {
         Border3D border = region.getBorderForFacet(RoughnessFacet.class);
-        ResourceFacet facet = new ResourceFacet(region.getRegion(), border, TeraMath.ceilToInt(gridSize / scale));
+        ResourceFacet facet = new ResourceFacet(region.getRegion(), border, gridSize);
 
         region.setRegionFacet(ResourceFacet.class, facet);
     }

--- a/src/main/java/org/terasology/dynamicCities/world/SolidRasterizer.java
+++ b/src/main/java/org/terasology/dynamicCities/world/SolidRasterizer.java
@@ -23,21 +23,28 @@ import org.terasology.core.world.CoreBiome;
 import org.terasology.core.world.generator.facets.BiomeFacet;
 import org.terasology.dynamicCities.facets.ResourceFacet;
 import org.terasology.dynamicCities.rasterizer.CompatibleRasterizer;
-import org.terasology.engine.world.block.Block;
 import org.terasology.engine.world.chunks.Chunk;
 import org.terasology.engine.world.chunks.Chunks;
 import org.terasology.engine.world.generation.Region;
+import org.terasology.engine.world.generation.ScalableWorldRasterizer;
 import org.terasology.engine.world.generation.facets.DensityFacet;
 import org.terasology.engine.world.generation.facets.SeaLevelFacet;
 import org.terasology.engine.world.generation.facets.SurfacesFacet;
 
 /**
  */
-public class SolidRasterizer extends CompatibleRasterizer {
+public class SolidRasterizer extends CompatibleRasterizer implements ScalableWorldRasterizer {
 
-
+    /**
+     * This override is required since the one in {@link CompatibleRasterizer} overrides the one in {@link ScalableWorldRasterizer}.
+     */
     @Override
     public void generateChunk(Chunk chunk, Region chunkRegion) {
+        generateChunk(chunk, chunkRegion, 1);
+    }
+
+    @Override
+    public void generateChunk(Chunk chunk, Region chunkRegion, float scale) {
         DensityFacet solidityFacet = chunkRegion.getFacet(DensityFacet.class);
         SurfacesFacet surfaceFacet = chunkRegion.getFacet(SurfacesFacet.class);
         BiomeFacet biomeFacet = chunkRegion.getFacet(BiomeFacet.class);
@@ -52,7 +59,7 @@ public class SolidRasterizer extends CompatibleRasterizer {
             Biome biome = biomeFacet.get(pos2d);
             biomeRegistry.setBiome(biome, chunk, pos.x(), pos.y(), pos.z());
 
-            int posY = pos.y() + chunk.getChunkWorldOffsetY();
+            float posY = (pos.y() + chunk.getChunkWorldOffsetY()) * scale;
             float density = solidityFacet.get(pos);
             chunk.chunkToWorldPosition(pos,  worldPos);
 


### PR DESCRIPTION
There's no reason for it not to be, it just hadn't been implemented. This is required for the terrain to generate when using LOD chunks in Metal Renegades (https://github.com/Terasology/MetalRenegades/pull/162).