### PR TITLE
refactor(test): replaced old annotations

### DIFF
--- a/src/test/java/org/terasology/dynamicCities/region/RegionEntitiesTest.java
+++ b/src/test/java/org/terasology/dynamicCities/region/RegionEntitiesTest.java
@@ -9,20 +9,18 @@ import org.joml.Vector3f;
 import org.joml.Vector3fc;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.terasology.engine.entitySystem.entity.EntityRef;
-import org.terasology.engine.integrationenvironment.jupiter.Dependencies;
 import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
 import org.terasology.engine.logic.location.LocationComponent;
 import org.terasology.engine.registry.In;
 import org.terasology.engine.world.chunks.Chunks;
+import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
 
 import java.util.Arrays;
 import java.util.List;
@@ -31,9 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Tag("MteTest")
-@ExtendWith({MockitoExtension.class, MTEExtension.class})
-@Dependencies("DynamicCities")
+@IntegrationEnvironment(dependencies={"DynamicCities"})
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class RegionEntitiesTest {
     private static final int HALF_X = Chunks.SIZE_X / 2;

--- a/src/test/java/org/terasology/dynamicCities/settlements/SettlementEntityManagerTest.java
+++ b/src/test/java/org/terasology/dynamicCities/settlements/SettlementEntityManagerTest.java
@@ -31,13 +31,12 @@ import org.terasology.engine.context.Context;
 import org.terasology.engine.entitySystem.entity.EntityManager;
 import org.terasology.engine.entitySystem.entity.EntityRef;
 import org.terasology.engine.integrationenvironment.ModuleTestingHelper;
-import org.terasology.engine.integrationenvironment.jupiter.Dependencies;
 import org.terasology.engine.integrationenvironment.jupiter.MTEExtension;
-import org.terasology.engine.integrationenvironment.jupiter.UseWorldGenerator;
 import org.terasology.engine.logic.location.LocationComponent;
 import org.terasology.engine.registry.In;
 import org.terasology.engine.registry.InjectionHelper;
 import org.terasology.namegenerator.town.TownAssetTheme;
+import org.terasology.engine.integrationenvironment.jupiter.IntegrationEnvironment;
 
 import java.util.Optional;
 
@@ -45,10 +44,7 @@ import static com.google.common.truth.Truth8.assertThat;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-@Tag("MteTest")
-@ExtendWith({MTEExtension.class, MockitoExtension.class})
-@Dependencies("DynamicCities")
-@UseWorldGenerator("DynamicCities:FlatFaceted")
+@IntegrationEnvironment(dependencies={"DynamicCities"}, worldGenerator="DynamicCities:FlatFaceted")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class SettlementEntityManagerTest {
 


### PR DESCRIPTION
I replaced the old annotations in `SettlementEntityManagerTest` and `RegionEntitiesTest` by the new ones.

For more information, see https://github.com/MovingBlocks/Terasology/issues/5087