### PR TITLE
refactor: component field visibility public

### DIFF
--- a/src/main/java/org/terasology/dynamicCities/sites/SiteComponent.java
+++ b/src/main/java/org/terasology/dynamicCities/sites/SiteComponent.java
@@ -16,8 +16,8 @@ import java.util.Objects;
 @MappedContainer
 public class SiteComponent implements Component<SiteComponent> {
 
-    private Vector2i coords = new Vector2i();
-    private float radius;
+    public Vector2i coords = new Vector2i();
+    public float radius;
 
     /**
      * @param bx the x world coord (in blocks)

--- a/src/main/java/org/terasology/dynamicCities/sites/SiteFacetProvider.java
+++ b/src/main/java/org/terasology/dynamicCities/sites/SiteFacetProvider.java
@@ -76,20 +76,20 @@ public class SiteFacetProvider implements ConfigurableFacetProvider {
     }
 
 
-    private static class SiteConfiguration implements Component<SiteConfiguration> {
+    public static class SiteConfiguration implements Component<SiteConfiguration> {
 
         @Range(label = "Minimal town size", description = "Minimal town size in blocks", min = 1, max = 150, increment = 10, precision = 1)
-        private int minRadius = 50;
+        public int minRadius = 50;
 
         @Range(label = "Maximum town population", description = "Maximum town population", min = 10, max = 350, increment = 10, precision = 1)
-        private int maxPopulation = 100;
+        public int maxPopulation = 100;
 
         @Range(label = "Minimum distance between towns", min = 10, max = 1000, increment = 10, precision = 1)
-        private int minDistance = 128;
+        public int minDistance = 128;
 
         // Spawn is assumed to be at (0, 0, 0) for this setting.
         @Range(label = "Minimum distance from spawn", min = 0, max = 1000, increment = 10, precision = 1)
-        private int minSpawnGap = 200;
+        public int minSpawnGap = 200;
 
         @Override
         public void copyFrom(SiteConfiguration other) {


### PR DESCRIPTION
Newer Java versions are stricter with regards to access restrictions when using reflection.
This affects in particular the serialization of non-public fields in our component classes.
For this reason, we decided to exclude non-public component fields from serialization and refactor all non-public component fields to be public instead to ensure not breaking any game and especially saving/loading behavior.

A future module overhaul may have a more detailed look into the components and make considerate decisions to use non-public fields.

Relates to https://github.com/MovingBlocks/Terasology/pull/5191